### PR TITLE
Use absolute path for worker-build bin.

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,4 +3,4 @@ main = "build/worker/shim.mjs"
 compatibility_date = "2023-03-22"
 
 [build]
-command = "cargo install -q worker-build && worker-build --release"
+command = "cargo install -q worker-build && ~/.cargo/bin/worker-build --release"


### PR DESCRIPTION
I can't tell if something about my config's wrong, but the binary wasn't found without using its full path. So this might just have upside for those who don't have PATH set correctly and no downside?